### PR TITLE
Fix handling timeout errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -488,7 +488,12 @@ func (c *conn) errRecover(err *error) {
 			*err = v
 		}
 	case *net.OpError:
-		*err = driver.ErrBadConn
+		if v.Timeout() {
+			c.bad = true
+			*err = v
+		} else {
+			*err = driver.ErrBadConn
+		}
 	case error:
 		if v == io.EOF || v.(error).Error() == "remote error: handshake failure" {
 			*err = driver.ErrBadConn


### PR DESCRIPTION
The following comment in `database/sql/driver/driver.go` mentions
```
// To prevent duplicate operations, ErrBadConn should NOT be returned
// if there's a possibility that the database server might have
// performed the operation. Even if the server sends back an error,
// you shouldn't return ErrBadConn.
var ErrBadConn = errors.New("driver: bad connection")
```

Network error could be a timeout error where the database might
have executed the query.

This commit adds a check so that ErrBadConn is not returned
for timeout errors